### PR TITLE
Implement streaming batch translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This project is currently in **early development** – more features, documentat
 - Handle **massive files** (20k+ lines) with smart chunking.
 - Preserve keys, placeholders, formatting, and structure perfectly.
 - Provide **diff view** to approve or reject translation chunks before applying.
+- Stream huge locale files without loading them entirely in memory.
+- Dynamically adjust batch size based on token usage.
+- Optional parallel processing of translation batches.
 
 ---
 
@@ -38,6 +41,14 @@ This project is currently in **early development** – more features, documentat
 ## 🛠 Contributing
 
 This repo will soon open for contributions. Until then, development is handled on the `main` branch, with upstream updates tracked via `upstream-main`.
+
+## Streaming & Batch Options
+
+The extension can stream extremely large translation files. Configure the following settings in VS Code:
+
+- `i18nNexus.translationBatchSize` – number of keys processed per batch when streaming.
+- `i18nNexus.batchTokenLimit` – approximate token threshold before the batch size is reduced.
+- `i18nNexus.parallelBatchCount` – how many batches to translate in parallel.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,17 @@
         "i18nNexus.translationBatchSize": {
           "type": "number",
           "default": 500,
-          "description": "Number of keys to translate in each batch. Adjust based on the model's context window."
+          "description": "Number of keys to translate in each batch. Used when streaming very large files."
+        },
+        "i18nNexus.batchTokenLimit": {
+          "type": "number",
+          "default": 8000,
+          "description": "Approximate token threshold for a single batch. Batch size is reduced when this limit is approached."
+        },
+        "i18nNexus.parallelBatchCount": {
+          "type": "number",
+          "default": 1,
+          "description": "Number of batches to translate in parallel. Increase carefully based on provider limits."
         },
         "i18nNexus.basePath": {
           "type": "string",


### PR DESCRIPTION
## Summary
- add generator-based batch streaming
- update translation manager to write results chunk by chunk
- support dynamic batch size and parallel batches
- document streaming settings

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails to compile TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_68890b5dd92483248bb4d72cf6a3f1d3